### PR TITLE
feat: add structured errors module and home-path collapsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Shared CLI utilities for LLM-focused command-line tools.
 - **Internationalization**: Language detection and message management (Korean/English)
 - **Progress Indicators**: Emoji-based status messages for long-running operations
 - **Input Validation**: Type-safe validation for common input patterns
+- **Structured Errors**: Machine-readable error codes, suggestions, and exit-code mapping for agent-friendly CLIs
 
 ## Installation
 
@@ -114,6 +115,46 @@ const username = validatePattern('user123', /^[a-z0-9]+$/, 'Username', 'alphanum
 // validatePattern('user-123', /^[a-z0-9]+$/, 'Username') → throws "Username must be alphanumeric only"
 ```
 
+### Errors Module
+
+Throw structured errors with machine-readable codes and render them consistently
+for agents to parse:
+
+```typescript
+import {
+  CliError,
+  exitCodeForError,
+  toErrorOutput,
+  VALIDATION_ERROR,
+} from '@pleaseai/cli-toolkit/errors'
+import { outputData } from '@pleaseai/cli-toolkit/output'
+
+try {
+  if (!issue)
+    throw new CliError('Issue #999 not found', 'NOT_FOUND', ['Run `gh-please issue list`'])
+}
+catch (error) {
+  // Render a stable { error, code, help } payload (JSON or TOON)
+  outputData(toErrorOutput(error), 'toon')
+  // Map to a process exit code (2 for validation errors, otherwise 1)
+  process.exitCode = exitCodeForError(error)
+}
+```
+
+The built-in validators already throw `CliError` tagged with `VALIDATION_ERROR`
+(exit code `2`), so wrapping a command in the `try/catch` above gives you
+consistent structured errors and exit codes for free.
+
+The `collapseHomeDirectory` helper (in the output module) keeps paths portable
+in structured output:
+
+```typescript
+import { collapseHomeDirectory } from '@pleaseai/cli-toolkit/output'
+
+collapseHomeDirectory('/Users/alice/project/bin', '/Users/alice') // '~/project/bin'
+// The home directory defaults to os.homedir() when omitted.
+```
+
 ## API Reference
 
 ### Output Module
@@ -125,6 +166,7 @@ const username = validatePattern('user123', /^[a-z0-9]+$/, 'Username', 'alphanum
 - `filterFields(data, fields)` - Filter object/array to specified fields
 - `isStructuredOutput(options)` - Check if structured output is requested
 - `validateFormat(format)` - Validate output format
+- `collapseHomeDirectory(path, homeDir?)` - Replace a leading home-dir prefix with `~`
 
 ### i18n Module
 
@@ -159,6 +201,16 @@ const username = validatePattern('user123', /^[a-z0-9]+$/, 'Username', 'alphanum
 - `validateMaxLength(value, maxLength, fieldName?)` - Validate string length
 - `validateString(value, maxLength, fieldName?)` - Validate non-empty + max length
 - `validatePattern(value, pattern, fieldName?, description?)` - Validate regex pattern
+
+> Validators throw `CliError` with code `VALIDATION_ERROR` (a subclass of `Error`, so existing `try/catch` keeps working).
+
+### Errors Module
+
+- `CliError` - Structured error with `code` and `suggestions`
+- `exitCodeForError(error)` - Map an error to a process exit code (`2` for validation, else `1`)
+- `errorOutput(message, code, suggestions?)` - Build a `{ error, code, help? }` payload
+- `toErrorOutput(error)` - Convert any thrown value into a structured payload
+- `VALIDATION_ERROR` / `UNKNOWN_ERROR` - Built-in error code constants
 
 ## TypeScript Support
 

--- a/package.json
+++ b/package.json
@@ -17,12 +17,30 @@
     "errors"
   ],
   "exports": {
-    ".": "./dist/index.js",
-    "./output": "./dist/output/index.js",
-    "./i18n": "./dist/i18n/index.js",
-    "./progress": "./dist/progress/index.js",
-    "./validation": "./dist/validation/index.js",
-    "./errors": "./dist/errors/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./output": {
+      "types": "./dist/output/index.d.ts",
+      "default": "./dist/output/index.js"
+    },
+    "./i18n": {
+      "types": "./dist/i18n/index.d.ts",
+      "default": "./dist/i18n/index.js"
+    },
+    "./progress": {
+      "types": "./dist/progress/index.d.ts",
+      "default": "./dist/progress/index.js"
+    },
+    "./validation": {
+      "types": "./dist/validation/index.d.ts",
+      "default": "./dist/validation/index.js"
+    },
+    "./errors": {
+      "types": "./dist/errors/index.d.ts",
+      "default": "./dist/errors/index.js"
+    }
   },
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@pleaseai/cli-toolkit",
   "type": "module",
   "version": "0.2.0",
+  "packageManager": "bun@1.3.14",
   "description": "Shared CLI utilities for LLM-focused command-line tools",
   "author": "PleaseAI",
   "license": "MIT",
@@ -12,14 +13,16 @@
     "output",
     "i18n",
     "validation",
-    "progress"
+    "progress",
+    "errors"
   ],
   "exports": {
     ".": "./dist/index.js",
     "./output": "./dist/output/index.js",
     "./i18n": "./dist/i18n/index.js",
     "./progress": "./dist/progress/index.js",
-    "./validation": "./dist/validation/index.js"
+    "./validation": "./dist/validation/index.js",
+    "./errors": "./dist/errors/index.js"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -29,8 +32,8 @@
   ],
   "scripts": {
     "prebuild": "rm -rf dist",
-    "build": "bun build src/index.ts --outdir dist --target bun --format esm && bun build src/output/index.ts --outdir dist/output --target bun --format esm && bun build src/i18n/index.ts --outdir dist/i18n --target bun --format esm && bun build src/progress/index.ts --outdir dist/progress --target bun --format esm && bun build src/validation/index.ts --outdir dist/validation --target bun --format esm && tsc --emitDeclarationOnly --declaration --declarationDir dist",
-    "build:prod": "bun build src/index.ts --outdir dist --target bun --format esm --minify --sourcemap && bun build src/output/index.ts --outdir dist/output --target bun --format esm --minify --sourcemap && bun build src/i18n/index.ts --outdir dist/i18n --target bun --format esm --minify --sourcemap && bun build src/progress/index.ts --outdir dist/progress --target bun --format esm --minify --sourcemap && bun build src/validation/index.ts --outdir dist/validation --target bun --format esm --minify --sourcemap && tsc --emitDeclarationOnly --declaration --declarationDir dist",
+    "build": "bun build src/index.ts --outdir dist --target bun --format esm && bun build src/output/index.ts --outdir dist/output --target bun --format esm && bun build src/i18n/index.ts --outdir dist/i18n --target bun --format esm && bun build src/progress/index.ts --outdir dist/progress --target bun --format esm && bun build src/validation/index.ts --outdir dist/validation --target bun --format esm && bun build src/errors/index.ts --outdir dist/errors --target bun --format esm && tsc --emitDeclarationOnly --declaration --declarationDir dist",
+    "build:prod": "bun build src/index.ts --outdir dist --target bun --format esm --minify --sourcemap && bun build src/output/index.ts --outdir dist/output --target bun --format esm --minify --sourcemap && bun build src/i18n/index.ts --outdir dist/i18n --target bun --format esm --minify --sourcemap && bun build src/progress/index.ts --outdir dist/progress --target bun --format esm --minify --sourcemap && bun build src/validation/index.ts --outdir dist/validation --target bun --format esm --minify --sourcemap && bun build src/errors/index.ts --outdir dist/errors --target bun --format esm --minify --sourcemap && tsc --emitDeclarationOnly --declaration --declarationDir dist",
     "type-check": "tsc --noEmit",
     "test": "bun test",
     "test:coverage": "bun test --coverage",

--- a/src/errors/error.ts
+++ b/src/errors/error.ts
@@ -49,6 +49,32 @@ export class CliError extends Error {
 }
 
 /**
+ * Identify a {@link CliError}, tolerating multiple loaded copies of this module.
+ *
+ * A bare `instanceof` check fails when more than one copy of `CliError` exists
+ * in the running process — e.g. a consumer importing helpers from two subpaths
+ * (each bundled with its own copy), or two versions of the toolkit coexisting in
+ * a dependency tree. Each copy defines a structurally identical but
+ * reference-distinct class, so `instanceof` silently misclassifies the error and
+ * its `code`/`suggestions` are lost. Falling back to a structural `name`/`code`
+ * check keeps detection reliable across those boundaries.
+ *
+ * @param error - Any thrown value
+ * @returns `true` if the value is a `CliError` (or structurally equivalent)
+ */
+export function isCliError(error: unknown): error is CliError {
+  if (error instanceof CliError) {
+    return true
+  }
+  return (
+    error instanceof Error
+    && error.name === 'CliError'
+    && 'code' in error
+    && typeof (error as { code: unknown }).code === 'string'
+  )
+}
+
+/**
  * Map an error to a process exit code.
  *
  * Validation errors return `2` (usage error), everything else returns `1`.
@@ -67,7 +93,7 @@ export class CliError extends Error {
  * ```
  */
 export function exitCodeForError(error: unknown): number {
-  if (error instanceof CliError && error.code === VALIDATION_ERROR) {
+  if (isCliError(error) && error.code === VALIDATION_ERROR) {
     return 2
   }
   return 1

--- a/src/errors/error.ts
+++ b/src/errors/error.ts
@@ -1,0 +1,74 @@
+/**
+ * Error code for validation failures (bad/invalid user input).
+ *
+ * Maps to process exit code `2` via {@link exitCodeForError}, following the
+ * convention that usage/validation errors are distinct from runtime failures.
+ */
+export const VALIDATION_ERROR = 'VALIDATION_ERROR'
+
+/**
+ * Default error code used when an error has no more specific classification.
+ *
+ * Maps to process exit code `1` via {@link exitCodeForError}.
+ */
+export const UNKNOWN_ERROR = 'UNKNOWN'
+
+/**
+ * Structured error for CLI / agent-facing tools.
+ *
+ * Carries a machine-readable `code` and optional `suggestions` alongside the
+ * human message, so callers can render a consistent structured payload
+ * (`{ error, code, help }`) and map the error to a stable process exit code.
+ *
+ * Because it extends the built-in `Error`, existing `try/catch` and
+ * `expect(...).toThrow(message)` checks keep working unchanged.
+ *
+ * @example
+ * ```typescript
+ * throw new CliError(
+ *   'Issue #999 not found',
+ *   'NOT_FOUND',
+ *   ['Run `gh-please issue list` to see open issues'],
+ * )
+ * ```
+ */
+export class CliError extends Error {
+  /**
+   * @param message - Human-readable error message
+   * @param code - Machine-readable error code (default: `'UNKNOWN'`)
+   * @param suggestions - Optional actionable hints surfaced to the user/agent
+   */
+  constructor(
+    message: string,
+    public readonly code: string = UNKNOWN_ERROR,
+    public readonly suggestions: string[] = [],
+  ) {
+    super(message)
+    this.name = 'CliError'
+  }
+}
+
+/**
+ * Map an error to a process exit code.
+ *
+ * Validation errors return `2` (usage error), everything else returns `1`.
+ * Mirrors the common Unix convention where `2` signals misuse/invalid input.
+ *
+ * @param error - Any thrown value
+ * @returns Exit code (`2` for validation errors, otherwise `1`)
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   validateNonEmptyString('')
+ * } catch (error) {
+ *   process.exitCode = exitCodeForError(error) // 2
+ * }
+ * ```
+ */
+export function exitCodeForError(error: unknown): number {
+  if (error instanceof CliError && error.code === VALIDATION_ERROR) {
+    return 2
+  }
+  return 1
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Structured error utilities for CLI / agent-facing tools.
+ *
+ * Provides a structured error class with machine-readable codes and
+ * suggestions, exit-code mapping, and helpers to render errors as a stable
+ * `{ error, code, help }` payload.
+ *
+ * @module errors
+ */
+
+// Error class, codes, and exit-code mapping
+export {
+  CliError,
+  exitCodeForError,
+  UNKNOWN_ERROR,
+  VALIDATION_ERROR,
+} from './error.ts'
+
+// Structured error output
+export { errorOutput, toErrorOutput } from './output.ts'
+export type { ErrorOutput } from './output.ts'

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -12,6 +12,7 @@
 export {
   CliError,
   exitCodeForError,
+  isCliError,
   UNKNOWN_ERROR,
   VALIDATION_ERROR,
 } from './error.ts'

--- a/src/errors/output.ts
+++ b/src/errors/output.ts
@@ -1,0 +1,76 @@
+import { CliError, UNKNOWN_ERROR } from './error.ts'
+
+/**
+ * Structured, machine-readable error payload.
+ *
+ * Designed to be rendered directly with the output module
+ * (`outputData(payload, 'toon')` / `outputData(payload, 'json')`), giving
+ * agents a stable shape to parse instead of free-form stderr text.
+ */
+export interface ErrorOutput {
+  /** Human-readable error message */
+  error: string
+  /** Machine-readable error code */
+  code: string
+  /** Optional actionable hints (omitted when empty) */
+  help?: string[]
+}
+
+/**
+ * Build a structured error payload from explicit fields.
+ *
+ * The `help` key is omitted entirely when there are no suggestions, keeping
+ * the output minimal.
+ *
+ * @param message - Human-readable error message
+ * @param code - Machine-readable error code
+ * @param suggestions - Optional actionable hints
+ * @returns Structured error payload
+ *
+ * @example
+ * ```typescript
+ * errorOutput('Invalid output format: xml', 'VALIDATION_ERROR', [
+ *   'Supported formats: json, toon',
+ * ])
+ * // { error: 'Invalid output format: xml', code: 'VALIDATION_ERROR', help: ['Supported formats: json, toon'] }
+ * ```
+ */
+export function errorOutput(
+  message: string,
+  code: string,
+  suggestions: string[] = [],
+): ErrorOutput {
+  const output: ErrorOutput = { error: message, code }
+  if (suggestions.length > 0) {
+    output.help = suggestions
+  }
+  return output
+}
+
+/**
+ * Convert any thrown value into a structured error payload.
+ *
+ * - {@link CliError} preserves its `code` and `suggestions`.
+ * - A generic `Error` keeps its message with code `'UNKNOWN'`.
+ * - Any other value is stringified with code `'UNKNOWN'`.
+ *
+ * @param error - Any thrown value
+ * @returns Structured error payload
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await run()
+ * } catch (error) {
+ *   outputData(toErrorOutput(error), 'toon')
+ *   process.exitCode = exitCodeForError(error)
+ * }
+ * ```
+ */
+export function toErrorOutput(error: unknown): ErrorOutput {
+  if (error instanceof CliError) {
+    return errorOutput(error.message, error.code, error.suggestions)
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  return errorOutput(message, UNKNOWN_ERROR)
+}

--- a/src/errors/output.ts
+++ b/src/errors/output.ts
@@ -1,4 +1,4 @@
-import { CliError, UNKNOWN_ERROR } from './error.ts'
+import { isCliError, UNKNOWN_ERROR } from './error.ts'
 
 /**
  * Structured, machine-readable error payload.
@@ -68,8 +68,8 @@ export function errorOutput(
  * ```
  */
 export function toErrorOutput(error: unknown): ErrorOutput {
-  if (error instanceof CliError) {
-    return errorOutput(error.message, error.code, error.suggestions)
+  if (isCliError(error)) {
+    return errorOutput(error.message, error.code, error.suggestions ?? [])
   }
   const message = error instanceof Error ? error.message : String(error)
   return errorOutput(message, UNKNOWN_ERROR)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,24 @@
  */
 
 // ============================================================================
-// Output Module
+// Errors Module
+// ============================================================================
+
+export {
+  // Structured error class, codes, and exit-code mapping
+  CliError,
+  // Structured error output
+  errorOutput,
+  exitCodeForError,
+  toErrorOutput,
+  UNKNOWN_ERROR,
+  VALIDATION_ERROR,
+} from './errors/index.ts'
+
+export type { ErrorOutput } from './errors/index.ts'
+
+// ============================================================================
+// i18n Module
 // ============================================================================
 
 export {
@@ -26,10 +43,12 @@ export {
 export type { CommonMessages, Language, MessageDictionary } from './i18n/types.ts'
 
 // ============================================================================
-// i18n Module
+// Output Module
 // ============================================================================
 
 export {
+  // Path display helpers
+  collapseHomeDirectory,
   // TOON output
   encodeToon,
   filterFields,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   // Structured error output
   errorOutput,
   exitCodeForError,
+  isCliError,
   toErrorOutput,
   UNKNOWN_ERROR,
   VALIDATION_ERROR,

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -13,6 +13,9 @@ export type { OutputFormat, OutputOptions } from './types.ts'
 // Field filtering
 export { parseFields, filterFields } from './filter.ts'
 
+// Path display helpers
+export { collapseHomeDirectory } from './path.ts'
+
 // TOON output
 export { encodeToon, outputToon } from './toon.ts'
 

--- a/src/output/json.ts
+++ b/src/output/json.ts
@@ -1,4 +1,5 @@
 import type { OutputFormat, OutputOptions } from './types.ts'
+import { CliError, VALIDATION_ERROR } from '../errors/error.ts'
 import { filterFields } from './filter.ts'
 import { outputToon } from './toon.ts'
 
@@ -61,7 +62,7 @@ export function isValidFormat(format: unknown): format is OutputFormat {
  *
  * @param format - Format string to validate
  * @returns The validated format
- * @throws {Error} If format is not valid
+ * @throws {CliError} If format is not valid (code: `VALIDATION_ERROR`)
  *
  * @example
  * ```typescript
@@ -75,8 +76,9 @@ export function validateFormat(format: unknown): OutputFormat {
     const formatStr = format === undefined || format === null
       ? String(format)
       : `${format}`
-    throw new Error(
+    throw new CliError(
       `Invalid output format: ${formatStr}. Supported formats: ${VALID_FORMATS.join(', ')}`,
+      VALIDATION_ERROR,
     )
   }
   return format

--- a/src/output/path.ts
+++ b/src/output/path.ts
@@ -1,0 +1,38 @@
+import { homedir } from 'node:os'
+
+/**
+ * Collapse a leading home-directory prefix to `~` for stable, portable output.
+ *
+ * Avoids leaking absolute home paths (e.g. `/Users/alice/...`) into structured
+ * output, keeping results deterministic across machines and users — useful when
+ * an agent or snapshot test consumes the output.
+ *
+ * Only an exact leading match of the home directory is collapsed; paths outside
+ * the home directory are returned unchanged.
+ *
+ * @param path - Absolute path to normalize
+ * @param homeDir - Home directory to collapse (default: `os.homedir()`)
+ * @returns Path with the home prefix replaced by `~`, or the original path
+ *
+ * @example
+ * ```typescript
+ * collapseHomeDirectory('/Users/alice/project/bin', '/Users/alice')
+ * // '~/project/bin'
+ *
+ * collapseHomeDirectory('/usr/local/bin', '/Users/alice')
+ * // '/usr/local/bin' (unchanged)
+ * ```
+ */
+export function collapseHomeDirectory(path: string, homeDir = homedir()): string {
+  if (!homeDir || !path.startsWith(homeDir)) {
+    return path
+  }
+  // Require a real path boundary after the prefix so a sibling directory that
+  // merely shares the home basename (e.g. `/Users/alicebob` vs `/Users/alice`)
+  // is not collapsed.
+  const rest = path.slice(homeDir.length)
+  if (rest === '' || rest.startsWith('/')) {
+    return `~${rest}`
+  }
+  return path
+}

--- a/src/output/path.ts
+++ b/src/output/path.ts
@@ -24,14 +24,20 @@ import { homedir } from 'node:os'
  * ```
  */
 export function collapseHomeDirectory(path: string, homeDir = homedir()): string {
-  if (!homeDir || !path.startsWith(homeDir)) {
+  if (!homeDir) {
+    return path
+  }
+  // Drop any trailing separator so a caller-supplied `~/` or `C:\Users\alice\`
+  // still matches and the collapsed result keeps a single boundary separator.
+  const normalizedHome = homeDir.replace(/[/\\]+$/, '')
+  if (!normalizedHome || !path.startsWith(normalizedHome)) {
     return path
   }
   // Require a real path boundary after the prefix so a sibling directory that
   // merely shares the home basename (e.g. `/Users/alicebob` vs `/Users/alice`)
-  // is not collapsed.
-  const rest = path.slice(homeDir.length)
-  if (rest === '' || rest.startsWith('/')) {
+  // is not collapsed. Accept both POSIX (`/`) and Windows (`\`) separators.
+  const rest = path.slice(normalizedHome.length)
+  if (rest === '' || rest.startsWith('/') || rest.startsWith('\\')) {
     return `~${rest}`
   }
   return path

--- a/src/validation/numeric.ts
+++ b/src/validation/numeric.ts
@@ -1,10 +1,12 @@
+import { CliError, VALIDATION_ERROR } from '../errors/error.ts'
+
 /**
  * Validate that a string represents a positive integer
  *
  * @param value - String value to validate
  * @param fieldName - Field name for error messages (default: "Value")
  * @returns Parsed positive integer
- * @throws {Error} If value is not a positive integer
+ * @throws {CliError} If value is not a positive integer (code: `VALIDATION_ERROR`)
  *
  * @example
  * ```typescript
@@ -18,12 +20,12 @@
 export function validatePositiveInteger(value: string, fieldName = 'Value'): number {
   // Check if the string contains only digits
   if (!/^\d+$/.test(value)) {
-    throw new Error(`${fieldName} must be a positive integer`)
+    throw new CliError(`${fieldName} must be a positive integer`, VALIDATION_ERROR)
   }
 
   const parsed = Number.parseInt(value, 10)
   if (Number.isNaN(parsed) || parsed <= 0) {
-    throw new Error(`${fieldName} must be a positive integer`)
+    throw new CliError(`${fieldName} must be a positive integer`, VALIDATION_ERROR)
   }
   return parsed
 }
@@ -34,7 +36,7 @@ export function validatePositiveInteger(value: string, fieldName = 'Value'): num
  * @param value - Value to validate (string or number)
  * @param fieldName - Field name for error messages (default: "Value")
  * @returns Parsed positive integer
- * @throws {Error} If value is not a positive integer
+ * @throws {CliError} If value is not a positive integer (code: `VALIDATION_ERROR`)
  *
  * @example
  * ```typescript
@@ -48,7 +50,7 @@ export function validateNumericId(value: string | number, fieldName = 'ID'): num
   const num = typeof value === 'string' ? Number.parseInt(value, 10) : value
 
   if (Number.isNaN(num) || num <= 0 || !Number.isInteger(num)) {
-    throw new Error(`${fieldName} must be a positive integer`)
+    throw new CliError(`${fieldName} must be a positive integer`, VALIDATION_ERROR)
   }
 
   return num
@@ -62,7 +64,7 @@ export function validateNumericId(value: string | number, fieldName = 'ID'): num
  * @param max - Maximum value (inclusive)
  * @param fieldName - Field name for error messages (default: "Value")
  * @returns The validated number
- * @throws {Error} If value is outside the range
+ * @throws {CliError} If value is outside the range (code: `VALIDATION_ERROR`)
  *
  * @example
  * ```typescript
@@ -79,7 +81,7 @@ export function validateRange(
   fieldName = 'Value',
 ): number {
   if (value < min || value > max) {
-    throw new Error(`${fieldName} must be between ${min} and ${max}`)
+    throw new CliError(`${fieldName} must be between ${min} and ${max}`, VALIDATION_ERROR)
   }
   return value
 }

--- a/src/validation/text.ts
+++ b/src/validation/text.ts
@@ -1,10 +1,12 @@
+import { CliError, VALIDATION_ERROR } from '../errors/error.ts'
+
 /**
  * Validate that a string is not empty (after trimming)
  *
  * @param value - String value to validate
  * @param fieldName - Field name for error messages (default: "Value")
  * @returns Trimmed non-empty string
- * @throws {Error} If value is empty or undefined
+ * @throws {CliError} If value is empty or undefined (code: `VALIDATION_ERROR`)
  *
  * @example
  * ```typescript
@@ -21,7 +23,7 @@ export function validateNonEmptyString(
   fieldName = 'Value',
 ): string {
   if (!value || value.trim().length === 0) {
-    throw new Error(`${fieldName} cannot be empty`)
+    throw new CliError(`${fieldName} cannot be empty`, VALIDATION_ERROR)
   }
   return value.trim()
 }
@@ -33,7 +35,7 @@ export function validateNonEmptyString(
  * @param maxLength - Maximum allowed length
  * @param fieldName - Field name for error messages (default: "Value")
  * @returns The validated string
- * @throws {Error} If value exceeds maxLength
+ * @throws {CliError} If value exceeds maxLength (code: `VALIDATION_ERROR`)
  *
  * @example
  * ```typescript
@@ -48,8 +50,9 @@ export function validateMaxLength(
   fieldName = 'Value',
 ): string {
   if (value.length > maxLength) {
-    throw new Error(
+    throw new CliError(
       `${fieldName} cannot exceed ${maxLength} characters (got ${value.length})`,
+      VALIDATION_ERROR,
     )
   }
   return value
@@ -62,7 +65,7 @@ export function validateMaxLength(
  * @param maxLength - Maximum allowed length
  * @param fieldName - Field name for error messages (default: "Value")
  * @returns Trimmed, validated string
- * @throws {Error} If value is empty or exceeds maxLength
+ * @throws {CliError} If value is empty or exceeds maxLength (code: `VALIDATION_ERROR`)
  *
  * @example
  * ```typescript
@@ -89,7 +92,7 @@ export function validateString(
  * @param fieldName - Field name for error messages (default: "Value")
  * @param patternDescription - Human-readable pattern description
  * @returns The validated string
- * @throws {Error} If value doesn't match the pattern
+ * @throws {CliError} If value doesn't match the pattern (code: `VALIDATION_ERROR`)
  *
  * @example
  * ```typescript
@@ -113,7 +116,7 @@ export function validatePattern(
     const description = patternDescription
       ? `be ${patternDescription}`
       : `match pattern ${pattern.toString()}`
-    throw new Error(`${fieldName} must ${description}`)
+    throw new CliError(`${fieldName} must ${description}`, VALIDATION_ERROR)
   }
   return value
 }

--- a/test/errors/error.test.ts
+++ b/test/errors/error.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import { CliError, exitCodeForError, UNKNOWN_ERROR, VALIDATION_ERROR } from '../../src/errors/error'
+
+describe('CliError', () => {
+  test('should be an instance of Error', () => {
+    const error = new CliError('boom')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(CliError)
+  })
+
+  test('should expose the message', () => {
+    expect(new CliError('boom').message).toBe('boom')
+  })
+
+  test('should default code to UNKNOWN', () => {
+    expect(new CliError('boom').code).toBe(UNKNOWN_ERROR)
+    expect(UNKNOWN_ERROR).toBe('UNKNOWN')
+  })
+
+  test('should carry a custom code', () => {
+    expect(new CliError('boom', 'NOT_FOUND').code).toBe('NOT_FOUND')
+  })
+
+  test('should default suggestions to an empty array', () => {
+    expect(new CliError('boom').suggestions).toEqual([])
+  })
+
+  test('should carry suggestions', () => {
+    const error = new CliError('boom', 'NOT_FOUND', ['try this'])
+    expect(error.suggestions).toEqual(['try this'])
+  })
+
+  test('should set the error name', () => {
+    expect(new CliError('boom').name).toBe('CliError')
+  })
+
+  test('should be catchable as a thrown error', () => {
+    expect(() => {
+      throw new CliError('cannot be empty', VALIDATION_ERROR)
+    }).toThrow('cannot be empty')
+  })
+})
+
+describe('exitCodeForError', () => {
+  test('should return 2 for validation errors', () => {
+    expect(exitCodeForError(new CliError('bad', VALIDATION_ERROR))).toBe(2)
+  })
+
+  test('should return 1 for CliError with a non-validation code', () => {
+    expect(exitCodeForError(new CliError('bad', 'NOT_FOUND'))).toBe(1)
+  })
+
+  test('should return 1 for a generic Error', () => {
+    expect(exitCodeForError(new Error('bad'))).toBe(1)
+  })
+
+  test('should return 1 for a non-error value', () => {
+    expect(exitCodeForError('bad')).toBe(1)
+    expect(exitCodeForError(undefined)).toBe(1)
+  })
+})

--- a/test/errors/error.test.ts
+++ b/test/errors/error.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, test } from 'bun:test'
-import { CliError, exitCodeForError, UNKNOWN_ERROR, VALIDATION_ERROR } from '../../src/errors/error'
+import { CliError, exitCodeForError, isCliError, UNKNOWN_ERROR, VALIDATION_ERROR } from '../../src/errors/error'
+
+/**
+ * A `CliError` from a second copy of the module: same shape, distinct class.
+ * Reproduces the multi-instance scenario where `instanceof CliError` fails.
+ */
+class ForeignCliError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string = UNKNOWN_ERROR,
+    public readonly suggestions: string[] = [],
+  ) {
+    super(message)
+    this.name = 'CliError'
+  }
+}
 
 describe('CliError', () => {
   test('should be an instance of Error', () => {
@@ -41,9 +56,33 @@ describe('CliError', () => {
   })
 })
 
+describe('isCliError', () => {
+  test('should recognize a CliError instance', () => {
+    expect(isCliError(new CliError('boom'))).toBe(true)
+  })
+
+  test('should recognize a CliError from another module copy by shape', () => {
+    expect(isCliError(new ForeignCliError('boom', VALIDATION_ERROR))).toBe(true)
+  })
+
+  test('should reject a generic Error', () => {
+    expect(isCliError(new Error('boom'))).toBe(false)
+  })
+
+  test('should reject non-error values', () => {
+    expect(isCliError('boom')).toBe(false)
+    expect(isCliError({ name: 'CliError', code: 'X' })).toBe(false)
+    expect(isCliError(undefined)).toBe(false)
+  })
+})
+
 describe('exitCodeForError', () => {
   test('should return 2 for validation errors', () => {
     expect(exitCodeForError(new CliError('bad', VALIDATION_ERROR))).toBe(2)
+  })
+
+  test('should return 2 for a validation CliError from another module copy', () => {
+    expect(exitCodeForError(new ForeignCliError('bad', VALIDATION_ERROR))).toBe(2)
   })
 
   test('should return 1 for CliError with a non-validation code', () => {

--- a/test/errors/output.test.ts
+++ b/test/errors/output.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { CliError, VALIDATION_ERROR } from '../../src/errors/error'
+import { errorOutput, toErrorOutput } from '../../src/errors/output'
+
+describe('errorOutput', () => {
+  test('should build a minimal payload without suggestions', () => {
+    expect(errorOutput('boom', 'UNKNOWN')).toEqual({
+      error: 'boom',
+      code: 'UNKNOWN',
+    })
+  })
+
+  test('should omit the help key when suggestions are empty', () => {
+    const output = errorOutput('boom', 'UNKNOWN', [])
+    expect(output).not.toHaveProperty('help')
+  })
+
+  test('should include the help key when suggestions are present', () => {
+    expect(errorOutput('boom', 'VALIDATION_ERROR', ['fix it'])).toEqual({
+      error: 'boom',
+      code: 'VALIDATION_ERROR',
+      help: ['fix it'],
+    })
+  })
+})
+
+describe('toErrorOutput', () => {
+  test('should preserve code and suggestions from a CliError', () => {
+    const error = new CliError('Issue not found', 'NOT_FOUND', ['run list'])
+    expect(toErrorOutput(error)).toEqual({
+      error: 'Issue not found',
+      code: 'NOT_FOUND',
+      help: ['run list'],
+    })
+  })
+
+  test('should map a validation CliError code through', () => {
+    const error = new CliError('Value cannot be empty', VALIDATION_ERROR)
+    expect(toErrorOutput(error)).toEqual({
+      error: 'Value cannot be empty',
+      code: 'VALIDATION_ERROR',
+    })
+  })
+
+  test('should fall back to UNKNOWN for a generic Error', () => {
+    expect(toErrorOutput(new Error('boom'))).toEqual({
+      error: 'boom',
+      code: 'UNKNOWN',
+    })
+  })
+
+  test('should stringify a non-error value', () => {
+    expect(toErrorOutput('boom')).toEqual({
+      error: 'boom',
+      code: 'UNKNOWN',
+    })
+  })
+})

--- a/test/errors/output.test.ts
+++ b/test/errors/output.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from 'bun:test'
-import { CliError, VALIDATION_ERROR } from '../../src/errors/error'
+import { CliError, UNKNOWN_ERROR, VALIDATION_ERROR } from '../../src/errors/error'
 import { errorOutput, toErrorOutput } from '../../src/errors/output'
+
+/** A `CliError` from a second module copy: same shape, distinct class. */
+class ForeignCliError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string = UNKNOWN_ERROR,
+    public readonly suggestions: string[] = [],
+  ) {
+    super(message)
+    this.name = 'CliError'
+  }
+}
 
 describe('errorOutput', () => {
   test('should build a minimal payload without suggestions', () => {
@@ -27,6 +39,15 @@ describe('errorOutput', () => {
 describe('toErrorOutput', () => {
   test('should preserve code and suggestions from a CliError', () => {
     const error = new CliError('Issue not found', 'NOT_FOUND', ['run list'])
+    expect(toErrorOutput(error)).toEqual({
+      error: 'Issue not found',
+      code: 'NOT_FOUND',
+      help: ['run list'],
+    })
+  })
+
+  test('should preserve code and suggestions from a CliError of another module copy', () => {
+    const error = new ForeignCliError('Issue not found', 'NOT_FOUND', ['run list'])
     expect(toErrorOutput(error)).toEqual({
       error: 'Issue not found',
       code: 'NOT_FOUND',

--- a/test/errors/validation-integration.test.ts
+++ b/test/errors/validation-integration.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import { CliError, exitCodeForError, VALIDATION_ERROR } from '../../src/errors/error'
+import { validateFormat } from '../../src/output/json'
+import { validateNumericId, validatePositiveInteger, validateRange } from '../../src/validation/numeric'
+import { validateMaxLength, validateNonEmptyString, validatePattern } from '../../src/validation/text'
+
+/**
+ * Each validator below should throw a CliError tagged with VALIDATION_ERROR,
+ * which maps to exit code 2. This is the wiring that makes structured errors
+ * usable end-to-end (catch -> toErrorOutput -> exitCodeForError).
+ */
+function captureError(fn: () => unknown): unknown {
+  try {
+    fn()
+  }
+  catch (error) {
+    return error
+  }
+  throw new Error('expected function to throw')
+}
+
+const cases: Array<[string, () => unknown]> = [
+  ['validateNonEmptyString', () => validateNonEmptyString('')],
+  ['validateMaxLength', () => validateMaxLength('hello', 3)],
+  ['validatePattern', () => validatePattern('abc-123', /^[a-z0-9]+$/)],
+  ['validatePositiveInteger', () => validatePositiveInteger('0')],
+  ['validateNumericId', () => validateNumericId(-1)],
+  ['validateRange', () => validateRange(11, 1, 10)],
+  ['validateFormat', () => validateFormat('xml')],
+]
+
+describe('validators throw structured CliError(VALIDATION_ERROR)', () => {
+  for (const [name, fn] of cases) {
+    test(`${name} throws a validation CliError mapped to exit code 2`, () => {
+      const error = captureError(fn)
+      expect(error).toBeInstanceOf(CliError)
+      expect((error as CliError).code).toBe(VALIDATION_ERROR)
+      expect(exitCodeForError(error)).toBe(2)
+    })
+  }
+})

--- a/test/output/path.test.ts
+++ b/test/output/path.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+import { collapseHomeDirectory } from '../../src/output/path'
+
+describe('collapseHomeDirectory', () => {
+  test('should collapse a leading home directory to ~', () => {
+    expect(collapseHomeDirectory('/Users/alice/project/bin', '/Users/alice')).toBe('~/project/bin')
+  })
+
+  test('should collapse an exact home directory match', () => {
+    expect(collapseHomeDirectory('/Users/alice', '/Users/alice')).toBe('~')
+  })
+
+  test('should leave paths outside the home directory unchanged', () => {
+    expect(collapseHomeDirectory('/usr/local/bin', '/Users/alice')).toBe('/usr/local/bin')
+  })
+
+  test('should not collapse a sibling directory that shares the home basename', () => {
+    expect(collapseHomeDirectory('/Users/alicebob/x', '/Users/alice')).toBe('/Users/alicebob/x')
+  })
+
+  test('should not collapse when home directory is empty', () => {
+    expect(collapseHomeDirectory('/usr/local/bin', '')).toBe('/usr/local/bin')
+  })
+
+  test('should default to os.homedir when homeDir is omitted', () => {
+    const home = process.env.HOME ?? ''
+    if (home) {
+      expect(collapseHomeDirectory(`${home}/work`)).toBe('~/work')
+    }
+    // Always assert at least once even when HOME is unset.
+    expect(collapseHomeDirectory('/outside/path')).toBe('/outside/path')
+  })
+})

--- a/test/output/path.test.ts
+++ b/test/output/path.test.ts
@@ -1,3 +1,4 @@
+import { homedir } from 'node:os'
 import { describe, expect, test } from 'bun:test'
 import { collapseHomeDirectory } from '../../src/output/path'
 
@@ -22,12 +23,20 @@ describe('collapseHomeDirectory', () => {
     expect(collapseHomeDirectory('/usr/local/bin', '')).toBe('/usr/local/bin')
   })
 
+  test('should collapse a Windows-style home directory', () => {
+    expect(collapseHomeDirectory('C:\\Users\\alice\\project', 'C:\\Users\\alice')).toBe('~\\project')
+  })
+
+  test('should ignore a trailing separator on the home directory', () => {
+    expect(collapseHomeDirectory('/Users/alice/project', '/Users/alice/')).toBe('~/project')
+  })
+
   test('should default to os.homedir when homeDir is omitted', () => {
-    const home = process.env.HOME ?? ''
+    const home = homedir()
     if (home) {
       expect(collapseHomeDirectory(`${home}/work`)).toBe('~/work')
     }
-    // Always assert at least once even when HOME is unset.
+    // Always assert at least once even when the home directory is unset.
     expect(collapseHomeDirectory('/outside/path')).toBe('/outside/path')
   })
 })


### PR DESCRIPTION
## Summary

Adopts two agent-DX features from [`axi-sdk-js`](https://github.com/kunchenguid/axi/tree/main/packages/axi-sdk-js) into the toolkit (features 1 & 2 from the prior analysis):

1. **Structured errors module** (`./errors` subpath)
   - `CliError` — `Error` subclass carrying a machine-readable `code` + `suggestions[]`
   - `exitCodeForError(error)` — maps `VALIDATION_ERROR` → exit `2`, everything else → `1`
   - `errorOutput(message, code, suggestions?)` / `toErrorOutput(error)` — produce a stable `{ error, code, help? }` payload renderable as JSON/TOON
   - `VALIDATION_ERROR` / `UNKNOWN_ERROR` constants
2. **`collapseHomeDirectory(path, homeDir?)`** (output module) — replaces a leading home prefix with `~`, **path-boundary aware** (a sibling like `/Users/alicebob` is not collapsed against home `/Users/alice`), for portable/deterministic output.

All existing validators (`validation/text.ts`, `validation/numeric.ts`, `output/json.ts` format check) now throw `CliError` tagged `VALIDATION_ERROR`. Since `CliError extends Error`, existing `try/catch` and `toThrow(message)` assertions keep working unchanged.

Also pins `packageManager` to `bun@1.3.14`.

## Why

Raises the toolkit's agent-DX: structured, machine-parseable errors with stable exit codes — directly aligned with the `agent-dx-cli-scale` rubric (structured JSON errors, safety rails) added in #5.

## Files

- New: `src/errors/{error,output,index}.ts`, `src/output/path.ts` + tests
- Wired: validators throw `CliError`; `package.json` (`./errors` export, build steps, `packageManager`); `src/index.ts` / `src/output/index.ts` barrels; `README.md`

## Test plan

- [x] `bun test` — 164 pass, 0 fail (32 new tests incl. sibling-prefix boundary regression + end-to-end catch→code→exit-code across all 7 validators)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — emits `dist/errors/` with `.d.ts`
- [x] `/review:review-code` — 6 aspects; only one Important (README example accuracy), fixed in this branch

## Notes

- Backward compatible: `CliError` is an `Error`; no message text changed.
- Library uses `@byjohann/toon`; `axi-sdk-js` uses `@toon-format/toon` — kept the toolkit's existing dependency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured, machine-readable errors and home-path collapsing to make CLI output agent-friendly and portable. Validators now throw `CliError`, enabling stable exit codes and consistent JSON/TOON error payloads; path collapsing is boundary-aware and cross-OS.

- **New Features**
  - `./errors` module: `CliError` (code + suggestions), `exitCodeForError` (validation → 2, else 1), `errorOutput` / `toErrorOutput`, and `isCliError` for robust detection across multiple package copies.
  - Validators (`text`, `numeric`, `validateFormat`) now throw `CliError` with `VALIDATION_ERROR`.
  - Added `collapseHomeDirectory(path, homeDir?)` to replace a leading home prefix with `~` (path-boundary aware, handles Windows `\` and trailing slash in `homeDir`).

<sup>Written for commit 9c030e2b31ab24ebbb530eaa55be0c7807a6c672. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced structured CLI errors with machine-readable codes, suggestions, and an error payload format.
  * Added public “Errors” utilities (including error detection across module copies) and standardized exit-code mapping for validation failures.
  * Added `collapseHomeDirectory` for portable `~` formatting in output.

* **Bug Fixes**
  * Updated validators and output format checks to throw standardized validation errors.

* **Documentation**
  * Expanded README and API reference for the new errors/output utilities and payload shape.

* **Tests**
  * Added unit and integration coverage for structured errors and home-directory collapsing.

* **Chores**
  * Updated package export mappings and build outputs for the new errors entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->