### PR TITLE
fix(errors)!: align UNKNOWN_ERROR value + document isCliError guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ The built-in validators already throw `CliError` tagged with `VALIDATION_ERROR`
 (exit code `2`), so wrapping a command in the `try/catch` above gives you
 consistent structured errors and exit codes for free.
 
+> **Detecting a `CliError`:** use the `isCliError(error)` type guard instead of a
+> bare `error instanceof CliError`. Each subpath (`/errors`, `/output`,
+> `/validation`) bundles its own copy of `CliError`, so a direct `instanceof`
+> check can silently return `false` for an error thrown by a different subpath
+> (or by a second copy of the package in the dependency tree). `isCliError`,
+> `toErrorOutput`, and `exitCodeForError` already handle this for you.
+
+```typescript
+import { isCliError } from '@pleaseai/cli-toolkit/errors'
+
+if (isCliError(error)) {
+  // error.code / error.suggestions are safe to read here
+}
+```
+
 The `collapseHomeDirectory` helper (in the output module) keeps paths portable
 in structured output:
 
@@ -207,6 +222,7 @@ collapseHomeDirectory('/Users/alice/project/bin', '/Users/alice') // '~/project/
 ### Errors Module
 
 - `CliError` - Structured error with `code` and `suggestions`
+- `isCliError(error)` - Type guard for `CliError`, robust across subpath/version boundaries (prefer over `instanceof`)
 - `exitCodeForError(error)` - Map an error to a process exit code (`2` for validation, else `1`)
 - `errorOutput(message, code, suggestions?)` - Build a `{ error, code, help? }` payload
 - `toErrorOutput(error)` - Convert any thrown value into a structured payload

--- a/src/errors/error.ts
+++ b/src/errors/error.ts
@@ -11,7 +11,7 @@ export const VALIDATION_ERROR = 'VALIDATION_ERROR'
  *
  * Maps to process exit code `1` via {@link exitCodeForError}.
  */
-export const UNKNOWN_ERROR = 'UNKNOWN'
+export const UNKNOWN_ERROR = 'UNKNOWN_ERROR'
 
 /**
  * Structured error for CLI / agent-facing tools.
@@ -35,7 +35,7 @@ export const UNKNOWN_ERROR = 'UNKNOWN'
 export class CliError extends Error {
   /**
    * @param message - Human-readable error message
-   * @param code - Machine-readable error code (default: `'UNKNOWN'`)
+   * @param code - Machine-readable error code (default: `'UNKNOWN_ERROR'`)
    * @param suggestions - Optional actionable hints surfaced to the user/agent
    */
   constructor(

--- a/src/errors/output.ts
+++ b/src/errors/output.ts
@@ -51,8 +51,8 @@ export function errorOutput(
  * Convert any thrown value into a structured error payload.
  *
  * - {@link CliError} preserves its `code` and `suggestions`.
- * - A generic `Error` keeps its message with code `'UNKNOWN'`.
- * - Any other value is stringified with code `'UNKNOWN'`.
+ * - A generic `Error` keeps its message with code `'UNKNOWN_ERROR'`.
+ * - Any other value is stringified with code `'UNKNOWN_ERROR'`.
  *
  * @param error - Any thrown value
  * @returns Structured error payload

--- a/test/errors/error.test.ts
+++ b/test/errors/error.test.ts
@@ -27,9 +27,9 @@ describe('CliError', () => {
     expect(new CliError('boom').message).toBe('boom')
   })
 
-  test('should default code to UNKNOWN', () => {
+  test('should default code to UNKNOWN_ERROR', () => {
     expect(new CliError('boom').code).toBe(UNKNOWN_ERROR)
-    expect(UNKNOWN_ERROR).toBe('UNKNOWN')
+    expect(UNKNOWN_ERROR).toBe('UNKNOWN_ERROR')
   })
 
   test('should carry a custom code', () => {

--- a/test/errors/output.test.ts
+++ b/test/errors/output.test.ts
@@ -63,17 +63,17 @@ describe('toErrorOutput', () => {
     })
   })
 
-  test('should fall back to UNKNOWN for a generic Error', () => {
+  test('should fall back to UNKNOWN_ERROR for a generic Error', () => {
     expect(toErrorOutput(new Error('boom'))).toEqual({
       error: 'boom',
-      code: 'UNKNOWN',
+      code: 'UNKNOWN_ERROR',
     })
   })
 
   test('should stringify a non-error value', () => {
     expect(toErrorOutput('boom')).toEqual({
       error: 'boom',
-      code: 'UNKNOWN',
+      code: 'UNKNOWN_ERROR',
     })
   })
 })

--- a/test/errors/output.test.ts
+++ b/test/errors/output.test.ts
@@ -16,14 +16,14 @@ class ForeignCliError extends Error {
 
 describe('errorOutput', () => {
   test('should build a minimal payload without suggestions', () => {
-    expect(errorOutput('boom', 'UNKNOWN')).toEqual({
+    expect(errorOutput('boom', UNKNOWN_ERROR)).toEqual({
       error: 'boom',
-      code: 'UNKNOWN',
+      code: UNKNOWN_ERROR,
     })
   })
 
   test('should omit the help key when suggestions are empty', () => {
-    const output = errorOutput('boom', 'UNKNOWN', [])
+    const output = errorOutput('boom', UNKNOWN_ERROR, [])
     expect(output).not.toHaveProperty('help')
   })
 


### PR DESCRIPTION
Addresses two post-merge review findings from greptile-apps on #6.

## Changes

### 1. `fix(errors)!`: align `UNKNOWN_ERROR` value with its name (breaking)
`UNKNOWN_ERROR` was `'UNKNOWN'` while `VALIDATION_ERROR` is `'VALIDATION_ERROR'`. A consumer comparing `error.code === 'UNKNOWN_ERROR'` (a natural guess from the export name) never matched the runtime value `'UNKNOWN'`. Aligned to `'UNKNOWN_ERROR'` for consistency.

> **BREAKING CHANGE:** the `code` field of unknown/fallback errors (`toErrorOutput`) and `CliError`'s default code change from `'UNKNOWN'` → `'UNKNOWN_ERROR'`. Consumers comparing against the literal `'UNKNOWN'` must update; using the exported `UNKNOWN_ERROR` constant is unaffected. Acceptable pre-1.0.

### 2. `docs(errors)`: document `isCliError` guard
Warns against bare `instanceof CliError` across subpaths (each subpath bundles its own copy of the class), points to the `isCliError` type guard, and adds it to the API reference.

## Validation
- `tsc --noEmit` ✅
- `eslint .` ✅
- `bun test` — 172 pass, 0 fail ✅

## Review threads
- https://github.com/pleaseai/cli-toolkit/pull/6#discussion_r3472248437 (UNKNOWN_ERROR)
- https://github.com/pleaseai/cli-toolkit/pull/6#discussion_r3472248531 (instanceof docs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the `UNKNOWN_ERROR` runtime value to `'UNKNOWN_ERROR'` to match its export and avoid mismatched comparisons. Also documents the `isCliError` guard to prevent `instanceof` issues across subpaths. This changes the default/unknown error code from `'UNKNOWN'` to `'UNKNOWN_ERROR'`.

- **Bug Fixes**
  - Align `UNKNOWN_ERROR` value; update code, tests (use the constant), and docs.
  - Add docs recommending `isCliError` over `instanceof CliError` for cross-subpath detection.

- **Migration**
  - Replace any checks against `'UNKNOWN'` with `'UNKNOWN_ERROR'` or compare to the exported `UNKNOWN_ERROR`.
  - Note: `toErrorOutput` now returns `'UNKNOWN_ERROR'` for generic/unknown errors.

<sup>Written for commit 6cc33b646003f5e2874db9822edac46ae4f59318. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the machine-readable error code for generic and unknown failures to `UNKNOWN_ERROR`.
  * Updated default CLI error behavior so newly created errors use `UNKNOWN_ERROR`.

* **Documentation**
  * Added guidance on detecting CLI-specific errors using `isCliError(error)` (avoiding `instanceof` pitfalls).
  * Updated the API reference to include `isCliError(error)`.
  * Clarified that generic `Error` and non-error throws map to code `UNKNOWN_ERROR`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->