### PR TITLE
ci(codecov): add codecov.yml config and Socket badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # @pleaseai/cli-toolkit
 
 [![npm version](https://badge.fury.io/js/@pleaseai%2Fcli-toolkit.svg)](https://badge.fury.io/js/@pleaseai%2Fcli-toolkit)
-[![CI](https://github.com/pleaseai/gh-please/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/cli-toolkit/actions/workflows/ci.yml)
+[![CI](https://github.com/pleaseai/cli-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/cli-toolkit/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/pleaseai/cli-toolkit/graph/badge.svg?token=lAPii2Uj1a)](https://codecov.io/gh/pleaseai/cli-toolkit)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/@pleaseai/cli-toolkit)](https://socket.dev/npm/package/@pleaseai/cli-toolkit)
 [![code style](https://antfu.me/badge-code-style.svg)](https://github.com/antfu/eslint-config)
 
 Shared CLI utilities for LLM-focused command-line tools.

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,13 +14,13 @@ coverage:
         threshold: 0%
 
 comment:
-  layout: "reach, diff, flags, files"
+  layout: 'reach, diff, flags, files'
   behavior: default
   require_changes: false
 
 # Source-only coverage: tests, build output, and type-only files add noise.
 ignore:
-  - "test"
-  - "dist"
-  - "**/*.test.ts"
-  - "**/*.d.ts"
+  - test
+  - dist
+  - '**/*.test.ts'
+  - '**/*.d.ts'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+# Codecov configuration
+# Docs: https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    project:
+      default:
+        # Compare against the base commit; allow a small dip to avoid flaky failures.
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # New/changed lines in a PR should be well covered.
+        target: 80%
+        threshold: 0%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+# Source-only coverage: tests, build output, and type-only files add noise.
+ignore:
+  - "test"
+  - "dist"
+  - "**/*.test.ts"
+  - "**/*.d.ts"


### PR DESCRIPTION
Adds Codecov configuration and observability badges.

## Changes
- **`codecov.yml`** (new, validated via Codecov's validator → `Valid!`):
  - `project` status: `auto` target with a `1%` threshold (avoids flaky failures on tiny dips)
  - `patch` status: `80%` target for new/changed lines
  - `ignore`: `test`, `dist`, `*.test.ts`, `*.d.ts` (source-only coverage)
- **README — Socket badge**: added the Socket.dev package-health badge (Socket Security checks already run in CI)
- **README — CI badge fix**: the CI badge image pointed at the wrong repo (`pleaseai/gh-please`); corrected to `pleaseai/cli-toolkit`

## Notes
- Coverage upload already works: `bunfig.toml` emits `coverage/lcov.info` and `ci.yml` uploads it via `codecov/codecov-action@v5`. This PR only adds the missing config file + badge.
- The codecov badge was already present and is unchanged.
- Socket badge URL uses Socket's standard format; couldn't render-verify from the sandbox (Socket blocks non-browser requests with 403). Please confirm it renders on GitHub.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Codecov config to stabilize coverage checks: 80% patch target, 1% project threshold, ignoring `test`, `dist`, `**/*.test.ts`, and `**/*.d.ts`; also fix YAML scalar style in `codecov.yml` to satisfy repo lint.

Update README to add the Socket.dev package-health badge and fix the CI badge to point to `pleaseai/cli-toolkit`.

<sup>Written for commit 739d78e95555302b0568c3ea1a570f3fa75d68d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README status badges, including CI, code coverage, and security scanning badges.
* **Chores**
  * Added coverage configuration with project and patch thresholds, plus reporting settings and excluded file patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->