### PR TITLE
ci(sonar): run SonarCloud scan and upload coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,7 @@ jobs:
       - name: Type check
         run: bun run type-check
 
-      - name: Run tests
-        run: bun test
-
-      - name: Generate coverage report
+      - name: Run tests with coverage
         run: bun run test:coverage
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so SonarCloud can attribute new code / blame accurately.
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -41,6 +44,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
         continue-on-error: true
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        continue-on-error: true
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
       - name: Build
         run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           # Full history so SonarCloud can attribute new code / blame accurately.
           fetch-depth: 0
+          # No later step needs authenticated git; keep the token out of .git/config.
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,9 @@ sonar.sources=src
 sonar.tests=test
 sonar.test.inclusions=test/**/*.test.ts
 
+# Enable type-aware TypeScript analysis
+sonar.typescript.tsconfigPath=tsconfig.json
+
 # Coverage produced by `bun test --coverage` (see bunfig.toml)
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.organization=pleaseai
+sonar.projectKey=pleaseai_cli-toolkit
+
+# Analyze source; tests live under test/
+sonar.sources=src
+sonar.tests=test
+sonar.test.inclusions=test/**/*.test.ts
+
+# Coverage produced by `bun test --coverage` (see bunfig.toml)
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Build output and coverage artifacts are not source
+sonar.exclusions=dist/**,coverage/**


### PR DESCRIPTION
Adds SonarCloud static analysis to CI and uploads test coverage to SonarCloud.

## Changes
- **`sonar-project.properties`** (new): `organization=pleaseai`, `projectKey=pleaseai_cli-toolkit`, `sources=src`, `tests=test`, and **`sonar.javascript.lcov.reportPaths=coverage/lcov.info`** so SonarCloud ingests the existing coverage report.
- **`.github/workflows/ci.yml`**:
  - new **SonarCloud Scan** step (runs after `test:coverage`, so it reuses the generated `coverage/lcov.info`)
  - action pinned to a full commit SHA: `SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0` (per repo policy)
  - `SONAR_HOST_URL: https://sonarcloud.io` (required — the unified scanner defaults to a SonarQube host otherwise)
  - `fetch-depth: 0` on checkout for accurate new-code attribution / blame
  - `continue-on-error: true` — **non-blocking**, matching the Codecov step

## Coverage upload
`bunfig.toml` already emits `coverage/lcov.info` via `bun test --coverage`; the same file now feeds **both** Codecov and SonarCloud.

## ⚠️ Prerequisites (repo/org settings — not in this PR)
1. **`SONAR_TOKEN`** must be added to repo secrets (Settings → Secrets and variables → Actions).
2. The project **`pleaseai_cli-toolkit`** must exist in the **`pleaseai`** SonarCloud org. If your org slug / key differ, update `sonar-project.properties`.
3. **Disable "Automatic Analysis"** for the project in SonarCloud — CI-based analysis conflicts with it (the scan errors out otherwise). Non-blocking here, but the scan won't report until this is off.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SonarCloud static analysis to CI with type-aware TypeScript analysis and upload coverage from `coverage/lcov.info`. The scan runs after coverage tests and is non-blocking.

- **New Features**
  - Added `sonar-project.properties` (org `pleaseai`, key `pleaseai_cli-toolkit`, `src`/`test` paths, test inclusions, `sonar.typescript.tsconfigPath=tsconfig.json`, lcov path, exclusions).
  - CI: run tests once with coverage; upload `coverage/lcov.info` to Codecov and SonarCloud; continue on error.
  - CI: checkout with `fetch-depth: 0` and `persist-credentials: false`; run SonarCloud Scan via pinned `SonarSource/sonarqube-scan-action` with `SONAR_HOST_URL=https://sonarcloud.io` and `SONAR_TOKEN`.

- **Migration**
  - Add `SONAR_TOKEN` to repo secrets.
  - Ensure the `pleaseai_cli-toolkit` project exists in the `pleaseai` SonarCloud org or update `sonar-project.properties`.
  - Disable “Automatic Analysis” in SonarCloud for this project.

<sup>Written for commit 732c5e4ac1d04c155b508a113910d47947e565b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI quality checks to improve blame attribution accuracy and streamline coverage generation.
  * Added a dedicated code analysis step after coverage is produced.
  * Refined code analysis configuration, including organization/project identifiers, source/test/coverage locations, TypeScript settings, and exclusions for build and coverage artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->