### PR TITLE
chore: keep release-please pre-1.0 (bump-minor-pre-major)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
       "release-type": "node",
       "package-name": "@pleaseai/cli-toolkit",
       "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
       "extra-files": [
         "package.json"
       ]


### PR DESCRIPTION
Sets `bump-minor-pre-major: true` so release-please bumps the **minor** for breaking changes while the library is pre-1.0, instead of jumping to 1.0.0.

## Why
The open release PR #7 proposed **1.0.0** because the `fix(errors)!` breaking change (#8) triggers release-please's default major bump. The public API is still evolving (0.2.0, modules recently added), so we want **0.3.0**, not a 1.0 stability commitment yet.

## Effect
After this merges, release-please re-runs on `main` and regenerates the release PR (#7) as **0.3.0**. Merging that PR then cuts the release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure `release-please` to bump the minor version for breaking changes while pre-1.0 by enabling `bump-minor-pre-major`. This keeps `@pleaseai/cli-toolkit` on 0.x and targets 0.3.0 for the next release instead of 1.0.0.

<sup>Written for commit 9f50eb5336295f06968c73c98cfad2a59d02ef0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release versioning behavior so pre-major releases will now move forward with minor-version bumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->