### PR TITLE
fix(ci): publish to npm with provenance instead of bun publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git tag to publish (e.g. v0.3.0) when re-running a release
+        required: true
 
 permissions:
   contents: write
@@ -31,14 +36,25 @@ jobs:
 
   npm-publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    # Publish on a fresh release, or manually for a given tag via workflow_dispatch.
+    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance (OIDC)
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4
@@ -54,7 +70,12 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Publish to npm
-        run: bun publish
+      # bun publish does not support npm provenance; build the tarball with bun
+      # and publish it via npm with --provenance (id-token: write enables OIDC).
+      - name: Pack tarball
+        run: bun pm pack
+
+      - name: Publish to npm (with provenance)
+        run: npm publish ./*.tgz --provenance --access public
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "description": "Shared CLI utilities for LLM-focused command-line tools",
   "author": "PleaseAI",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pleaseai/cli-toolkit.git"
+  },
   "keywords": [
     "cli",
     "toolkit",


### PR DESCRIPTION
The v0.3.0 release tag + GitHub release were created, but the **npm-publish job failed**:

```
404 Not Found: https://registry.npmjs.org/@pleaseai%2fcli-toolkit
'@pleaseai/cli-toolkit@0.3.0' does not exist in this registry
```

`bun publish` fails auth here and **can't emit npm provenance**, which the repo standard (CLAUDE.md) explicitly requires.

## Changes
- **Publish via `npm publish --provenance`** from a `bun pm pack` tarball (bun still does install/build)
- Add **`actions/setup-node`** (pinned to SHA) for registry auth + Node, and job-level **`id-token: write`** for OIDC provenance
- Add the **`repository` field** to `package.json` (required by `--provenance`)
- Add a **`workflow_dispatch`** trigger (with a `ref` input) so the already-tagged **v0.3.0** can be re-published manually after this merges

## Follow-up after merge
Run the workflow manually for the existing tag:
```
gh workflow run release-please.yml --ref main -f ref=v0.3.0
```

> Note: if `NPM_TOKEN` itself is expired/invalid, publish will still 401/404 — the secret may need refreshing (automation token with publish rights).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failed npm publish by switching from `bun publish` to `npm publish --provenance` with OIDC, so releases publish correctly and include required provenance.

- **Bug Fixes**
  - Publish via `npm publish --provenance` using a tarball from `bun pm pack`.
  - Add `actions/setup-node` for registry auth and set `id-token: write` for provenance.
  - Add the `repository` field to `package.json` (required by provenance).
  - Add `workflow_dispatch` with a `ref` input to manually publish existing tags (e.g., `v0.3.0`).

- **Migration**
  - After merge, republish the existing tag: `gh workflow run release-please.yml --ref main -f ref=v0.3.0`

<sup>Written for commit 9fd0060aaea2674bacb81c31c9e6a141d85fe5ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for manually triggering release publishing with a selected tag.
  * Updated publishing to include npm provenance and improved release authentication.
  * Added package repository metadata for better package publishing and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->