### PR TITLE
chore: add OSS community-health scaffold and badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report a problem to help us improve
+title: ""
+labels: ["bug"]
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behavior:
+
+1. ...
+2. ...
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Environment
+
+- Package version:
+- Runtime/OS:
+
+## Additional context
+
+Logs, screenshots, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/pleaseai/cli-toolkit/discussions
+    about: Ask questions and discuss ideas here instead of opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/pleaseai/cli-toolkit/security/advisories/new
+    about: Report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ""
+labels: ["enhancement"]
+---
+
+## Problem
+
+What problem does this feature solve? What is the use case?
+
+## Proposed solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives considered
+
+Other approaches you've thought about, and why this one is preferable.
+
+## Additional context
+
+Anything else that helps explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits
+- [ ] Tests added or updated, and the suite passes (`bun test`)
+- [ ] Lint/format pass (`bun run lint`)
+- [ ] Documentation updated if behavior changed
+- [ ] No breaking change, or a `BREAKING CHANGE:` note is included

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,13 @@
+# .worktreeinclude — gitignored files to copy into a new worktree.
+# Uses .gitignore syntax. Only files that match a pattern AND are git-ignored are copied.
+# Claude Code --worktree handles this automatically. External tools (orca/conductor) run
+#   bunx @pleaseai/worktreeinclude <source> <target> in their setup hook (see orca.yaml).
+# Details: Skill("standards:dev-tooling") → references/worktree-setup.md
+
+# Root environment variables
+.env
+.env.local
+.env.*.local
+
+# Claude Code local settings (symlink to shared settings — gitignored via .git/info/exclude)
+.claude/settings.local.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@pleaseai.dev**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Thanks for your interest in contributing! This guide covers how to get from a clone to a merged pull request.
+
+By participating, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). All documentation, code, comments, and commit messages in this repository are written in **English**.
+
+## Getting started
+
+This project uses [Bun](https://bun.sh) as its runtime and package manager.
+
+```bash
+git clone https://github.com/pleaseai/cli-toolkit.git
+cd cli-toolkit
+bun install         # install dependencies
+```
+
+Worktree setup (tools, dependencies, local files) is automated via `orca.yaml`.
+
+## Development workflow
+
+1. Create a branch from `main` (e.g. `feat/short-description` or `fix/issue-123`).
+2. Make focused changes — keep each pull request to one logical change.
+3. Run the checks below and make sure they pass.
+4. Open a pull request and fill out the template.
+
+```bash
+bun run lint        # lint and format
+bun test            # run the test suite
+bun run type-check  # type-check
+bun run build       # ensure it builds
+```
+
+## Commit messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): subject`, where `type` is one of `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, etc. Breaking changes include a `BREAKING CHANGE:` footer. Versioning and the changelog are generated automatically from these messages, so accurate types matter.
+
+## Pull requests
+
+- Reference the issue your PR addresses (e.g. `Closes #123`).
+- Use a Conventional-Commit-style PR title — it becomes the squash-merge commit.
+- Make sure CI is green before requesting review.
+
+## Reporting bugs and requesting features
+
+Open an issue using the bug report or feature request template. For security
+vulnerabilities, **do not** open a public issue — follow [SECURITY.md](./SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Passion Factory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/pleaseai/cli-toolkit/graph/badge.svg?token=lAPii2Uj1a)](https://codecov.io/gh/pleaseai/cli-toolkit)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/@pleaseai/cli-toolkit)](https://socket.dev/npm/package/@pleaseai/cli-toolkit)
 [![code style](https://antfu.me/badge-code-style.svg)](https://github.com/antfu/eslint-config)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/pleaseai/cli-toolkit/blob/main/LICENSE)
 
 Shared CLI utilities for LLM-focused command-line tools.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codecov](https://codecov.io/gh/pleaseai/cli-toolkit/graph/badge.svg?token=lAPii2Uj1a)](https://codecov.io/gh/pleaseai/cli-toolkit)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/@pleaseai/cli-toolkit)](https://socket.dev/npm/package/@pleaseai/cli-toolkit)
 [![code style](https://antfu.me/badge-code-style.svg)](https://github.com/antfu/eslint-config)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 Shared CLI utilities for LLM-focused command-line tools.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released major version. Older
+versions may receive fixes at the maintainers' discretion.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| older   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through GitHub's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
+go to the repository's **Security** tab and click **"Report a vulnerability"**.
+
+If you cannot use that channel, email **security@pleaseai.dev** instead.
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce, or a proof of concept
+- Affected versions, and any known mitigations
+
+## What to Expect
+
+- We aim to acknowledge your report within **72 hours**.
+- We will keep you informed of progress toward a fix and may ask for additional
+  detail.
+- Once a fix is released, we will credit you in the advisory unless you prefer
+  to remain anonymous.
+
+We ask that you give us a reasonable opportunity to address the issue before any
+public disclosure.

--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,18 @@
+# orca.yaml — setup script run when Orca creates a worktree.
+# Place at the project root; Orca runs scripts.setup on every new worktree (committed, so the whole team shares it).
+# Details: Skill("standards:dev-tooling") → references/worktree-setup.md
+#
+# Injected environment variables:
+#   $ORCA_ROOT_PATH     — main checkout (root repo) path; the source for copying gitignored local files
+#   $ORCA_WORKTREE_PATH — the newly created worktree path; the copy target
+#
+# This repo has no mise.toml and uses bun from the system PATH (single Bun-runtime package),
+# so it uses the mise-free variant: copy local files → install dependencies.
+
+scripts:
+  setup: |
+    set -e
+    # 1. Copy gitignored local files (.env*, .claude/settings.local.json) from the main checkout into the worktree.
+    bunx @pleaseai/worktreeinclude "$ORCA_ROOT_PATH" "$ORCA_WORKTREE_PATH"
+    # 2. Install dependencies inside the worktree (--frozen-lockfile so the worktree doesn't start dirty).
+    bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

Adds the OSS community-health scaffold and standard badges for `@pleaseai/cli-toolkit`.

- **LICENSE** — MIT, `Copyright (c) 2026 Passion Factory` (consistent with `package.json` `"license": "MIT"`).
- **CONTRIBUTING.md** — bun-based local setup (`bun install`, `bun run lint`, `bun test`, `bun run type-check`, `bun run build`); Conventional Commits guidance.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (contact: conduct@pleaseai.dev).
- **SECURITY.md** — private vulnerability reporting (contact: security@pleaseai.dev).
- **.github/PULL_REQUEST_TEMPLATE.md** and **.github/ISSUE_TEMPLATE/** (bug_report, feature_request, config.yml).
- **orca.yaml** + **.worktreeinclude** — bun-only worktree setup (no mise, no submodules): `bunx @pleaseai/worktreeinclude` then `bun install --frozen-lockfile`.
- **README** — added a `License: MIT` badge.

## Notes

- The README already had an npm-version badge (via `badge.fury.io`), so only the License badge was added — no duplicate npm badge.
- Existing `codecov.yml` and `sonar-project.properties` were left untouched.
- All documentation is written in English.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OSS community-health files and a MIT License badge for `@pleaseai/cli-toolkit`, plus a Bun-only worktree setup for consistent local development.

- **New Features**
  - Community health: MIT `LICENSE`, Contributor Covenant 2.1 (`conduct@pleaseai.dev`), `SECURITY.md` with private reporting (`security@pleaseai.dev`), and `CONTRIBUTING.md` (Bun workflow + Conventional Commits). Adds a License badge to the README.
  - Templates: PR template; issue templates for bugs and features; blank issues disabled; Discussions and Security advisory links added.
  - Dev tooling: `orca.yaml` and `.worktreeinclude` to bootstrap worktrees with `bunx @pleaseai/worktreeinclude` and `bun install --frozen-lockfile`.

<sup>Written for commit 5b7db67dec22b61ea69138f24cd0ef2e6173d86c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added GitHub issue templates for bug reports and feature requests, plus an issue template configuration to improve reporting and point users to the right channels.
  * Added a pull request template with a review/testing checklist.
  * Published code of conduct, contributing, and security policy docs; updated the README with a MIT license badge.
* **Chores**
  * Improved development worktree setup by introducing worktree inclusion rules for local environment/settings files and an automated worktree initialization hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->